### PR TITLE
Fixed Prefixed Key Example

### DIFF
--- a/src/main/scala/ExampleByteStringFormatter.scala
+++ b/src/main/scala/ExampleByteStringFormatter.scala
@@ -26,7 +26,7 @@ case class PrefixedKey[K: ByteStringSerializer](prefix: String, key: K)
 object PrefixedKey {
   implicit def serializer[K](implicit redisKey: ByteStringSerializer[K]) = new ByteStringSerializer[PrefixedKey[K]] {
     def serialize(data: PrefixedKey[K]): ByteString = {
-      ByteString(data.prefix + redisKey.serialize(data.key))
+      ByteString(data.prefix) ++ redisKey.serialize(data.key)
     }
   }
 }


### PR DESCRIPTION
PrefixedKey like in you example uses <key>:ByteString(...) as key in Redis
